### PR TITLE
feat: Implement portfolio components and pages

### DIFF
--- a/src/components/port/Grid.astro
+++ b/src/components/port/Grid.astro
@@ -1,0 +1,14 @@
+---
+import Item from '~/components/port/GridItem.astro';
+import type { Portfolio } from '~/types';
+
+export interface Props {
+  posts: Array<Portfolio>;
+}
+
+const { posts } = Astro.props;
+---
+
+<div class='grid gap-6 row-gap-5 md:grid-cols-2 lg:grid-cols-4 -mb-6'>
+  {posts.map((post) => <Item post={post} />)}
+</div>

--- a/src/components/port/GridItem.astro
+++ b/src/components/port/GridItem.astro
@@ -1,0 +1,67 @@
+---
+import type { Portfolio } from '~/types';
+import Image from '~/components/common/Image.astro';
+import { findImage } from '~/utils/images';
+import { getPermalink } from '~/utils/permalinks';
+
+export interface Props {
+  post: Portfolio;
+}
+
+const { post } = Astro.props;
+const image = await findImage(post.image);
+const link = getPermalink(post.permalink, 'page');
+---
+
+<article
+  class='mb-6 transition intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade'
+>
+  <div class='relative md:h-64 bg-gray-400 dark:bg-slate-700 rounded shadow-lg mb-6'>
+    {
+      image &&
+        (link ? (
+          <a href={link}>
+            <Image
+              src={image}
+              class='w-full md:h-full rounded shadow-lg bg-gray-400 dark:bg-slate-700'
+              widths={[400, 900]}
+              width={400}
+              sizes='(max-width: 900px) 400px, 900px'
+              alt={post.title}
+              aspectRatio='16:9'
+              layout='cover'
+              loading='lazy'
+              decoding='async'
+            />
+          </a>
+        ) : (
+          <Image
+            src={image}
+            class='w-full md:h-full rounded shadow-lg bg-gray-400 dark:bg-slate-700'
+            widths={[400, 900]}
+            width={400}
+            sizes='(max-width: 900px) 400px, 900px'
+            alt={post.title}
+            aspectRatio='16:9'
+            layout='cover'
+            loading='lazy'
+            decoding='async'
+          />
+        ))
+    }
+  </div>
+
+  <h3 class='text-xl sm:text-2xl font-bold leading-tight mb-2 font-heading dark:text-slate-300'>
+    {
+      link ? (
+        <a class='inline-block hover:text-primary dark:hover:text-blue-700 transition ease-in duration-200' href={link}>
+          {post.title}
+        </a>
+      ) : (
+        post.title
+      )
+    }
+  </h3>
+
+  <p class='text-muted dark:text-slate-400 text-lg'>{post.excerpt}</p>
+</article>

--- a/src/components/port/Headline.astro
+++ b/src/components/port/Headline.astro
@@ -1,0 +1,12 @@
+---
+const { title = await Astro.slots.render('default'), subtitle = await Astro.slots.render('subtitle') } = Astro.props;
+---
+
+<header class='mb-8 md:mb-16 text-center max-w-3xl mx-auto'>
+  <h1 class='text-4xl md:text-5xl font-bold leading-tighter tracking-tighter font-heading' set:html={title} />
+  {
+    subtitle && (
+      <div class='mt-2 md:mt-3 mx-auto text-xl text-gray-500 dark:text-slate-400 font-medium' set:html={subtitle} />
+    )
+  }
+</header>

--- a/src/components/port/List.astro
+++ b/src/components/port/List.astro
@@ -1,0 +1,20 @@
+---
+import Item from '~/components/port/ListItem.astro';
+import type { Portfolio } from '~/types';
+
+export interface Props {
+  posts: Array<Portfolio>;
+}
+
+const { posts } = Astro.props;
+---
+
+<ul>
+  {
+    posts.map((post) => (
+      <li class='mb-12 md:mb-20'>
+        <Item post={post} />
+      </li>
+    ))
+  }
+</ul>

--- a/src/components/port/ListItem.astro
+++ b/src/components/port/ListItem.astro
@@ -1,0 +1,119 @@
+---
+import type { ImageMetadata } from 'astro';
+import { Icon } from 'astro-icon/components';
+import Image from '~/components/common/Image.astro';
+import PortTags from '~/components/port/Tags.astro';
+
+import type { Portfolio } from '~/types';
+
+import { getPermalink } from '~/utils/permalinks';
+import { findImage } from '~/utils/images';
+import { getFormattedDate } from '~/utils/utils';
+
+export interface Props {
+  post: Portfolio;
+}
+
+const { post } = Astro.props;
+const image = (await findImage(post.image)) as ImageMetadata | undefined;
+
+const link = getPermalink(post.permalink, 'page');
+---
+
+<article
+  class={`max-w-md mx-auto md:max-w-none grid gap-6 md:gap-8 intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade ${image ? 'md:grid-cols-2' : ''}`}
+>
+  {
+    image &&
+      (link ? (
+        <a class='relative block group' href={link ?? 'javascript:void(0)'}>
+          <div class='relative h-0 pb-[56.25%] md:pb-[75%] md:h-72 lg:pb-[56.25%] overflow-hidden bg-gray-400 dark:bg-slate-700 rounded shadow-lg'>
+            {image && (
+              <Image
+                src={image}
+                class='absolute inset-0 object-cover w-full h-full mb-6 rounded shadow-lg bg-gray-400 dark:bg-slate-700'
+                widths={[400, 900]}
+                width={900}
+                sizes='(max-width: 900px) 400px, 900px'
+                alt={post.title}
+                aspectRatio='16:9'
+                loading='lazy'
+                decoding='async'
+              />
+            )}
+          </div>
+        </a>
+      ) : (
+        <div class='relative h-0 pb-[56.25%] md:pb-[75%] md:h-72 lg:pb-[56.25%] overflow-hidden bg-gray-400 dark:bg-slate-700 rounded shadow-lg'>
+          {image && (
+            <Image
+              src={image}
+              class='absolute inset-0 object-cover w-full h-full mb-6 rounded shadow-lg bg-gray-400 dark:bg-slate-700'
+              widths={[400, 900]}
+              width={900}
+              sizes='(max-width: 900px) 400px, 900px'
+              alt={post.title}
+              aspectRatio='16:9'
+              loading='lazy'
+              decoding='async'
+            />
+          )}
+        </div>
+      ))
+  }
+  <div class='mt-2'>
+    <header>
+      <div class='mb-1'>
+        <span class='text-sm'>
+          <Icon name='tabler:clock' class='w-3.5 h-3.5 inline-block -mt-0.5 dark:text-gray-400' />
+          <time datetime={String(post.publishDate)} class='inline-block'>{getFormattedDate(post.publishDate)}</time>
+          {
+            post.client && (
+              <>
+                {' '}
+                · <Icon name='tabler:briefcase' class='w-3.5 h-3.5 inline-block -mt-0.5 dark:text-gray-400' />
+                <span>{post.client}</span>
+              </>
+            )
+          }
+          {
+            post.category && (
+              <>
+                {' '}
+                ·{' '}
+                <a class='hover:underline' href={`/portfolio/category/${post.category}`}>
+                  {post.category}
+                </a>
+              </>
+            )
+          }
+        </span>
+      </div>
+      <h2 class='text-xl sm:text-2xl font-bold leading-tight mb-2 font-heading dark:text-slate-300'>
+        {
+          link ? (
+            <a
+              class='inline-block hover:text-primary dark:hover:text-blue-700 transition ease-in duration-200'
+              href={link}
+            >
+              {post.title}
+            </a>
+          ) : (
+            post.title
+          )
+        }
+      </h2>
+    </header>
+
+    {post.excerpt && <p class='flex-grow text-muted dark:text-slate-400 text-lg'>{post.excerpt}</p>}
+    {
+      post.tags && Array.isArray(post.tags) ? (
+        <footer class='mt-5'>
+          <PortTags tags={post.tags} />
+        </footer>
+      ) : (
+        <Fragment />
+      )
+    }
+  </div>
+</article>

--- a/src/components/port/RelatedPosts.astro
+++ b/src/components/port/RelatedPosts.astro
@@ -1,0 +1,28 @@
+---
+import { getRelatedPortfolioItems } from '~/utils/portfolio';
+import PortHighlightedPosts from '../widgets/PortHighlightedPosts.astro';
+import type { Portfolio } from '~/types';
+
+export interface Props {
+  post: Portfolio;
+}
+
+const { post } = Astro.props;
+
+const relatedPosts = post.tags ? await getRelatedPortfolioItems(post, 4) : [];
+---
+
+{
+  relatedPosts.length > 0 ? (
+    <PortHighlightedPosts
+      classes={{
+        container:
+          'pt-0 lg:pt-0 md:pt-0 intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade',
+      }}
+      title='Related Projects'
+      linkText='View All Projects'
+      linkUrl='/portfolio'
+      postIds={relatedPosts.map((post) => post.id)}
+    />
+  ) : null
+}

--- a/src/components/port/SinglePost.astro
+++ b/src/components/port/SinglePost.astro
@@ -1,0 +1,124 @@
+---
+import { Icon } from 'astro-icon/components';
+
+import Image from '~/components/common/Image.astro';
+import PortTags from '~/components/port/Tags.astro';
+import SocialShare from '~/components/common/SocialShare.astro';
+
+import { getFormattedDate } from '~/utils/utils';
+
+import type { Portfolio } from '~/types';
+
+export interface Props {
+  post: Portfolio;
+  url: string | URL;
+}
+
+const { post, url } = Astro.props;
+---
+
+<section class='py-8 sm:py-16 lg:py-20 mx-auto'>
+  <article>
+    <header
+      class={post.image
+        ? 'intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade'
+        : 'intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade'}
+    >
+      <div class='flex justify-between flex-col sm:flex-row max-w-3xl mx-auto mt-0 mb-2 px-4 sm:px-6 sm:items-center'>
+        <p>
+          <Icon name='tabler:clock' class='w-4 h-4 inline-block -mt-0.5 dark:text-gray-400' />
+          <time datetime={String(post.publishDate)} class='inline-block'>{getFormattedDate(post.publishDate)}</time>
+          {
+            post.client && (
+              <>
+                {' '}
+                · <Icon name='tabler:briefcase' class='w-4 h-4 inline-block -mt-0.5 dark:text-gray-400' />
+                <span class='inline-block'>{post.client}</span>
+              </>
+            )
+          }
+          {
+            post.category && (
+              <>
+                {' '}
+                ·{' '}
+                <a class='hover:underline inline-block' href={`/portfolio/category/${post.category}`}>
+                  {post.category}
+                </a>
+              </>
+            )
+          }
+          {
+            post.projectUrl && (
+              <>
+                {' '}
+                · <Icon name='tabler:link' class='w-4 h-4 inline-block -mt-0.5 dark:text-gray-400' />
+                <a
+                  href={post.projectUrl}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  class='hover:underline inline-block'
+                >
+                  View Project
+                </a>
+              </>
+            )
+          }
+        </p>
+      </div>
+
+      <h1
+        class='px-4 sm:px-6 max-w-3xl mx-auto text-4xl md:text-5xl font-bold leading-tighter tracking-tighter font-heading'
+      >
+        {post.title}
+      </h1>
+      <p
+        class='max-w-3xl mx-auto mt-4 mb-8 px-4 sm:px-6 text-xl md:text-2xl text-muted dark:text-slate-400 text-justify'
+      >
+        {post.excerpt}
+      </p>
+
+      {
+        post.image ? (
+          <Image
+            src={post.image}
+            class='max-w-full lg:max-w-[900px] mx-auto mb-6 sm:rounded-md bg-gray-400 dark:bg-slate-700'
+            widths={[400, 900]}
+            sizes='(max-width: 900px) 400px, 900px'
+            alt={post?.excerpt || ''}
+            width={900}
+            height={506}
+            loading='eager'
+            decoding='async'
+          />
+        ) : (
+          <div class='max-w-3xl mx-auto px-4 sm:px-6'>
+            <div class='border-t dark:border-slate-700' />
+          </div>
+        )
+      }
+
+      {
+        post.technologies && post.technologies.length > 0 && (
+          <div class='max-w-3xl mx-auto px-4 sm:px-6 mb-6'>
+            <h3 class='text-lg font-semibold mb-2'>Technologies Used:</h3>
+            <div class='flex flex-wrap gap-2'>
+              {post.technologies.map((tech) => (
+                <span class='bg-primary/10 text-primary px-3 py-1 rounded-full text-sm font-medium'>{tech}</span>
+              ))}
+            </div>
+          </div>
+        )
+      }
+    </header>
+    <div
+      class='mx-auto px-6 sm:px-6 max-w-3xl prose prose-md lg:prose-xl dark:prose-invert dark:prose-headings:text-slate-300 prose-headings:font-heading prose-headings:leading-tighter prose-headings:tracking-tighter prose-headings:font-bold prose-a:text-primary dark:prose-a:text-blue-400 prose-img:rounded-md prose-img:shadow-lg mt-8 prose-headings:scroll-mt-[80px] prose-li:my-0'
+    >
+      <slot />
+    </div>
+    <div class='mx-auto px-6 sm:px-6 max-w-3xl mt-8 flex justify-between flex-col sm:flex-row'>
+      <PortTags tags={post.tags} class='mr-5 rtl:mr-0 rtl:ml-5' />
+      <SocialShare url={url} text={post.title} class='mt-5 sm:mt-1 align-middle text-gray-500 dark:text-slate-600' />
+    </div>
+  </article>
+</section>

--- a/src/components/port/Tags.astro
+++ b/src/components/port/Tags.astro
@@ -1,0 +1,35 @@
+---
+import type { Portfolio } from '~/types';
+
+export interface Props {
+  tags: Portfolio['tags'];
+  class?: string;
+  title?: string | undefined;
+}
+
+const { tags, class: className = 'text-sm', title = undefined } = Astro.props;
+---
+
+{
+  tags && Array.isArray(tags) && (
+    <>
+      {title !== undefined && (
+        <span class='align-super font-normal underline underline-offset-4 decoration-2 dark:text-slate-400'>
+          {title}
+        </span>
+      )}
+      <ul class={className}>
+        {tags.map((tag) => (
+          <li class='bg-gray-100 dark:bg-slate-700 inline-block mr-2 rtl:mr-0 rtl:ml-2 mb-2 py-0.5 px-2 lowercase font-medium'>
+            <a
+              href={`/portfolio/tag/${tag}`}
+              class='text-muted dark:text-slate-300 hover:text-primary dark:hover:text-gray-200'
+            >
+              {tag}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </>
+  )
+}

--- a/src/components/port/ToPortLink.astro
+++ b/src/components/port/ToPortLink.astro
@@ -1,0 +1,19 @@
+---
+import { Icon } from 'astro-icon/components';
+import { I18N } from 'astrowind:config';
+import Button from '~/components/ui/Button.astro';
+
+const { textDirection } = I18N;
+---
+
+<div class='mx-auto px-6 sm:px-6 max-w-3xl pt-8 md:pt-4 pb-12 md:pb-20'>
+  <Button variant='tertiary' class='px-3 md:px-3' href='/portfolio'>
+    {
+      textDirection === 'rtl' ? (
+        <Icon name='tabler:chevron-right' class='w-5 h-5 mr-1 -ml-1.5 rtl:-mr-1.5 rtl:ml-1' />
+      ) : (
+        <Icon name='tabler:chevron-left' class='w-5 h-5 mr-1 -ml-1.5 rtl:-mr-1.5 rtl:ml-1' />
+      )
+    } Back to Portfolio
+  </Button>
+</div>

--- a/src/components/widgets/PortHighlightedPosts.astro
+++ b/src/components/widgets/PortHighlightedPosts.astro
@@ -1,0 +1,56 @@
+---
+import Grid from '~/components/port/Grid.astro';
+import { findPortfolioItemsByIds } from '~/utils/portfolio';
+import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
+import type { Widget } from '~/types';
+
+export interface Props extends Widget {
+  title?: string;
+  linkText?: string;
+  linkUrl?: string | URL;
+  information?: string;
+  postIds: string[];
+}
+
+const {
+  title = await Astro.slots.render('title'),
+  linkText = 'View all projects',
+  linkUrl = '/portfolio',
+  information = await Astro.slots.render('information'),
+  postIds = [],
+
+  id,
+  isDark = false,
+  classes = {},
+  bg = await Astro.slots.render('bg'),
+} = Astro.props;
+
+const posts = await findPortfolioItemsByIds(postIds);
+---
+
+<WidgetWrapper id={id} isDark={isDark} containerClass={classes?.container as string} bg={bg}>
+  <div class='flex flex-col lg:justify-between lg:flex-row mb-8'>
+    {
+      title && (
+        <div class='md:max-w-sm'>
+          <h2
+            class='text-3xl font-bold tracking-tight sm:text-4xl sm:leading-none group font-heading mb-2'
+            set:html={title}
+          />
+          {linkText && linkUrl && (
+            <a
+              class='text-muted dark:text-slate-400 hover:text-primary transition ease-in duration-200 block mb-6 lg:mb-0'
+              href={linkUrl}
+            >
+              {linkText} »
+            </a>
+          )}
+        </div>
+      )
+    }
+
+    {information && <p class='text-muted dark:text-slate-400 lg:text-sm lg:max-w-md' set:html={information} />}
+  </div>
+
+  <Grid posts={posts} />
+</WidgetWrapper>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -90,5 +90,5 @@ const portfolioCollection = defineCollection({
 
 export const collections = {
   post: postCollection,
-  portfolio: portfolioCollection,
+  port: portfolioCollection,
 };

--- a/src/data/port/brand-identity-innovate.md
+++ b/src/data/port/brand-identity-innovate.md
@@ -1,0 +1,36 @@
+---
+title: 'Corporate Brand Identity'
+excerpt: 'Complete brand identity design for a tech startup, including logo, colors, and visual guidelines'
+category: 'branding'
+tags: ['Brand Design', 'Logo Design', 'Visual Identity']
+client: 'InnovateTech'
+technologies: ['Adobe Illustrator', 'Figma', 'Adobe Photoshop']
+featured: false
+publishDate: 2024-03-10
+---
+
+# Corporate Brand Identity
+
+## Project Overview
+
+Created a comprehensive brand identity package for InnovateTech, a new startup in the AI technology sector, establishing a strong and memorable visual presence.
+
+## Deliverables
+
+- **Logo Design**: Modern, scalable logo in multiple variations
+- **Color Palette**: Carefully selected brand colors
+- **Typography**: Custom font selection and pairing
+- **Brand Guidelines**: Complete style guide for consistent application
+- **Marketing Materials**: Business cards, letterheads, and templates
+
+## Design Process
+
+1. Discovery and research phase
+2. Concept development and sketching
+3. Digital refinement and iterations
+4. Client feedback and revisions
+5. Final delivery and brand guide creation
+
+## Results
+
+The new brand identity successfully positioned InnovateTech as a modern, trustworthy tech company and was well-received by stakeholders and customers alike.

--- a/src/data/port/food-delivery-app.md
+++ b/src/data/port/food-delivery-app.md
@@ -1,0 +1,37 @@
+---
+title: 'Food Delivery App'
+excerpt: 'Multi-vendor food delivery mobile application with real-time tracking'
+category: 'mobile-app'
+tags: ['Flutter', 'Node.js', 'MongoDB']
+client: 'QuickEats'
+technologies: ['Flutter', 'Node.js', 'MongoDB', 'Socket.io', 'Google Maps']
+featured: false
+publishDate: 2024-05-15
+---
+
+# Food Delivery App
+
+## Project Overview
+
+Developed a feature-rich food delivery application connecting customers with local restaurants, featuring real-time order tracking and multiple payment options.
+
+## Key Features
+
+- **Restaurant Discovery**: Browse menus and ratings
+- **Real-time Tracking**: Live order and delivery status
+- **Multiple Payment Methods**: Cards, wallets, and cash on delivery
+- **Order History**: Easy reordering from past orders
+- **Push Notifications**: Order updates and promotional offers
+- **Rating System**: Customer reviews and restaurant ratings
+
+## Technologies Used
+
+- Flutter for cross-platform mobile development
+- Node.js and Express for backend API
+- MongoDB for flexible data storage
+- Socket.io for real-time communication
+- Google Maps API for navigation and tracking
+
+## Results
+
+Launched successfully with 20+ restaurant partners and growing rapidly with positive user feedback and increasing order volume.

--- a/src/data/port/hotel-booking-platform.md
+++ b/src/data/port/hotel-booking-platform.md
@@ -1,0 +1,39 @@
+---
+title: 'Hotel Booking Platform'
+excerpt: 'Comprehensive hotel booking system with advanced search and reservation management'
+image: '~/assets/images/food-serv.png'
+category: 'web-design'
+tags: ['Vue.js', 'Laravel', 'Stripe']
+client: 'LuxuryStay Hotels'
+projectUrl: 'https://luxurystay-demo.com'
+technologies: ['Vue.js', 'Laravel', 'MySQL', 'Stripe', 'Google Maps API']
+featured: true
+publishDate: 2024-04-05
+---
+
+# Hotel Booking Platform
+
+## Project Overview
+
+Built a full-featured hotel booking platform for LuxuryStay Hotels, enabling customers to search, compare, and book accommodations with ease.
+
+## Key Features
+
+- **Advanced Search**: Filter by location, price, amenities, and ratings
+- **Real-time Availability**: Up-to-date room availability
+- **Secure Payments**: Stripe integration for safe transactions
+- **User Accounts**: Booking history and profile management
+- **Admin Dashboard**: Comprehensive hotel and booking management
+- **Multi-language Support**: Available in 5 languages
+
+## Technologies Used
+
+- Vue.js 3 with Composition API
+- Laravel 10 for robust backend
+- MySQL database
+- Stripe payment gateway
+- Google Maps API for location services
+
+## Results
+
+The platform now handles over 1,000 bookings per month and has improved customer satisfaction scores by 35%.

--- a/src/data/port/mobile-banking-app.md
+++ b/src/data/port/mobile-banking-app.md
@@ -1,0 +1,36 @@
+---
+title: 'Mobile Banking App'
+excerpt: 'Secure and intuitive mobile banking application for iOS and Android'
+image: https://images.unsplash.com/photo-1534307671554-9a6d81f4d629?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1651&q=80
+category: 'mobile-app'
+tags: ['React Native', 'Firebase', 'FinTech']
+client: 'SecureBank'
+technologies: ['React Native', 'TypeScript', 'Firebase', 'Plaid API']
+featured: true
+publishDate: 2024-02-20
+---
+
+# Mobile Banking App
+
+## Project Overview
+
+Developed a comprehensive mobile banking application providing users with secure access to their accounts, transactions, and financial services on the go.
+
+## Key Features
+
+- **Biometric Authentication**: Fingerprint and Face ID support
+- **Real-time Notifications**: Instant transaction alerts
+- **Bill Payment**: Quick and easy bill management
+- **Account Management**: View balances, transactions, and statements
+- **Money Transfer**: Peer-to-peer payments and transfers
+
+## Technologies Used
+
+- React Native for cross-platform development
+- TypeScript for type safety
+- Firebase for authentication and real-time database
+- Plaid API for bank account integration
+
+## Results
+
+Successfully launched on both iOS and Android platforms with over 50,000 downloads in the first month and a 4.8-star rating.

--- a/src/data/port/web-design-project.md
+++ b/src/data/port/web-design-project.md
@@ -1,12 +1,11 @@
 ---
-title: "Modern E-commerce Website"
-excerpt: "A responsive e-commerce platform with modern design and seamless user experience"
-image: "/src/assets/images/portfolio/ecommerce-site.jpg"
-category: "web-design"
-tags: ["React", "Node.js", "Stripe"]
-client: "TechCorp Inc."
-projectUrl: "https://techcorp-demo.com"
-technologies: ["React", "TypeScript", "Tailwind CSS", "Stripe", "Sanity CMS"]
+title: 'Modern E-commerce Website'
+excerpt: 'A responsive e-commerce platform with modern design and seamless user experience'
+category: 'web-design'
+tags: ['React', 'Node.js', 'Stripe']
+client: 'TechCorp Inc.'
+projectUrl: 'https://techcorp-demo.com'
+technologies: ['React', 'TypeScript', 'Tailwind CSS', 'Stripe', 'Sanity CMS']
 featured: true
 publishDate: 2024-01-15
 ---

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -154,7 +154,7 @@ export const headerData = {
         },
         {
           text: 'Our Work',
-          href: getPermalink('/'),
+          href: getPermalink('/portfolio'),
         },
         {
           text: 'Careers',

--- a/src/pages/[...port]/[...page].astro
+++ b/src/pages/[...port]/[...page].astro
@@ -1,0 +1,49 @@
+---
+import type { InferGetStaticPropsType, GetStaticPaths } from 'astro';
+
+import Layout from '~/layouts/PageLayout.astro';
+import PortList from '~/components/port/List.astro';
+import Headline from '~/components/port/Headline.astro';
+import Pagination from '~/components/blog/Pagination.astro';
+
+import { portfolioListRobots, getStaticPathsPortfolioList } from '~/utils/portfolio';
+
+export const prerender = true;
+
+export const getStaticPaths = (async ({ paginate }) => {
+  return await getStaticPathsPortfolioList({ paginate });
+}) satisfies GetStaticPaths;
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+
+const { page } = Astro.props as Props;
+const currentPage = page.currentPage ?? 1;
+
+// const allCategories = await findCategories();
+// const allTags = await findTags();
+
+const metadata = {
+  title: `Portfolio${currentPage > 1 ? ` — Page ${currentPage}` : ''}`,
+  robots: {
+    index: portfolioListRobots?.index && currentPage === 1,
+    follow: portfolioListRobots?.follow,
+  },
+  openGraph: {
+    type: 'website',
+  },
+};
+---
+
+<Layout metadata={metadata}>
+  <section class='px-6 sm:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl'>
+    <Headline subtitle='Explore our portfolio of web design, mobile app development, branding and digital solutions'>
+      Our Portfolio
+    </Headline>
+    <PortList posts={page.data} />
+    <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
+    <!--
+      <PostTags tags={allCategories} class="mb-2" title="Search by Categories:" isCategory />
+      <PostTags tags={allTags}  title="Search by Tags:" />
+    -->
+  </section>
+</Layout>

--- a/src/pages/[...port]/[category]/[...page].astro
+++ b/src/pages/[...port]/[category]/[...page].astro
@@ -1,0 +1,37 @@
+---
+import type { InferGetStaticPropsType, GetStaticPaths } from 'astro';
+import { portfolioCategoryRobots, getStaticPathsPortfolioCategory } from '~/utils/portfolio';
+
+import Layout from '~/layouts/PageLayout.astro';
+import PortList from '~/components/port/List.astro';
+import Headline from '~/components/port/Headline.astro';
+import Pagination from '~/components/blog/Pagination.astro';
+
+export const prerender = true;
+
+export const getStaticPaths = (async ({ paginate }) => {
+  return await getStaticPathsPortfolioCategory({ paginate });
+}) satisfies GetStaticPaths;
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths> & { category: string };
+
+const { page, category } = Astro.props as Props;
+
+const currentPage = page.currentPage ?? 1;
+
+const metadata = {
+  title: `Portfolio Category '${category}' ${currentPage > 1 ? ` — Page ${currentPage}` : ''}`,
+  robots: {
+    index: portfolioCategoryRobots?.index,
+    follow: portfolioCategoryRobots?.follow,
+  },
+};
+---
+
+<Layout metadata={metadata}>
+  <section class='px-4 md:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl'>
+    <Headline>{category}</Headline>
+    <PortList posts={page.data} />
+    <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
+  </section>
+</Layout>

--- a/src/pages/[...port]/[tag]/[...page].astro
+++ b/src/pages/[...port]/[tag]/[...page].astro
@@ -1,0 +1,37 @@
+---
+import type { InferGetStaticPropsType, GetStaticPaths } from 'astro';
+import { portfolioTagRobots, getStaticPathsPortfolioTag } from '~/utils/portfolio';
+
+import Layout from '~/layouts/PageLayout.astro';
+import PortList from '~/components/port/List.astro';
+import Headline from '~/components/port/Headline.astro';
+import Pagination from '~/components/blog/Pagination.astro';
+
+export const prerender = true;
+
+export const getStaticPaths = (async ({ paginate }) => {
+  return await getStaticPathsPortfolioTag({ paginate });
+}) satisfies GetStaticPaths;
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+
+const { page, tag } = Astro.props as Props;
+
+const currentPage = page.currentPage ?? 1;
+
+const metadata = {
+  title: `Portfolio by tag '${tag}'${currentPage > 1 ? ` — Page ${currentPage} ` : ''}`,
+  robots: {
+    index: portfolioTagRobots?.index,
+    follow: portfolioTagRobots?.follow,
+  },
+};
+---
+
+<Layout metadata={metadata}>
+  <section class='px-4 md:px-6 py-12 sm:py-16 lg:py-20 mx-auto max-w-4xl'>
+    <Headline>Tag: {tag}</Headline>
+    <PortList posts={page.data} />
+    <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
+  </section>
+</Layout>

--- a/src/pages/[...port]/index.astro
+++ b/src/pages/[...port]/index.astro
@@ -1,0 +1,54 @@
+---
+import type { InferGetStaticPropsType, GetStaticPaths } from 'astro';
+
+import merge from 'lodash.merge';
+import type { ImageMetadata } from 'astro';
+import Layout from '~/layouts/PageLayout.astro';
+import SinglePost from '~/components/port/SinglePost.astro';
+import RelatedPosts from '~/components/port/RelatedPosts.astro';
+import ToPortLink from '~/components/port/ToPortLink.astro';
+
+import { getCanonical, getPermalink } from '~/utils/permalinks';
+import { getStaticPathsPortfolioItem, portfolioItemRobots } from '~/utils/portfolio';
+import { findImage } from '~/utils/images';
+import type { MetaData } from '~/types';
+
+export const prerender = true;
+
+export const getStaticPaths = (async () => {
+  return await getStaticPathsPortfolioItem();
+}) satisfies GetStaticPaths;
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+
+const { post } = Astro.props as Props;
+
+const url = getCanonical(getPermalink(post.permalink, 'port'));
+const image = (await findImage(post.image)) as ImageMetadata | string | undefined;
+
+const metadata = merge(
+  {
+    title: post.title,
+    description: post.excerpt,
+    robots: {
+      index: portfolioItemRobots?.index,
+      follow: portfolioItemRobots?.follow,
+    },
+    openGraph: {
+      type: 'article',
+      ...(image
+        ? { images: [{ url: image, width: (image as ImageMetadata)?.width, height: (image as ImageMetadata)?.height }] }
+        : {}),
+    },
+  },
+  { ...(post?.metadata ? { ...post.metadata, canonical: post.metadata?.canonical || url } : {}) }
+) as MetaData;
+---
+
+<Layout metadata={metadata}>
+  <SinglePost post={{ ...post, image: image }} url={url}>
+    {post.Content ? <post.Content /> : <Fragment set:html={post.content || ''} />}
+  </SinglePost>
+  <ToPortLink />
+  <RelatedPosts post={post} />
+</Layout>

--- a/src/utils/portfolio.ts
+++ b/src/utils/portfolio.ts
@@ -1,0 +1,285 @@
+import type { PaginateFunction } from 'astro';
+import { getCollection, render } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import type { Portfolio } from '~/types';
+import { cleanSlug, trimSlash, getPermalink } from './permalinks';
+
+const PORTFOLIO_BASE = 'portfolio';
+const PORT_CATEGORY_BASE = 'portfolio/category';
+const PORT_TAG_BASE = 'portfolio/tag';
+const PORTFOLIO_PERMALINK_PATTERN = `${PORTFOLIO_BASE}/%slug%`;
+
+const generatePermalink = async ({
+  id,
+  slug,
+  publishDate,
+  category,
+}: {
+  id: string;
+  slug: string;
+  publishDate: Date;
+  category: string | undefined;
+}) => {
+  const year = String(publishDate.getFullYear()).padStart(4, '0');
+  const month = String(publishDate.getMonth() + 1).padStart(2, '0');
+  const day = String(publishDate.getDate()).padStart(2, '0');
+  const hour = String(publishDate.getHours()).padStart(2, '0');
+  const minute = String(publishDate.getMinutes()).padStart(2, '0');
+  const second = String(publishDate.getSeconds()).padStart(2, '0');
+
+  const permalink = PORTFOLIO_PERMALINK_PATTERN.replace('%slug%', slug)
+    .replace('%id%', id)
+    .replace('%category%', category || '')
+    .replace('%year%', year)
+    .replace('%month%', month)
+    .replace('%day%', day)
+    .replace('%hour%', hour)
+    .replace('%minute%', minute)
+    .replace('%second%', second);
+
+  return permalink
+    .split('/')
+    .map((el) => trimSlash(el))
+    .filter((el) => !!el)
+    .join('/');
+};
+
+const getNormalizedPortfolio = async (item: CollectionEntry<'port'>): Promise<Portfolio> => {
+  const { id, data } = item;
+  const { Content, remarkPluginFrontmatter } = await render(item);
+
+  const {
+    publishDate: rawPublishDate = new Date(),
+    updateDate: rawUpdateDate,
+    title,
+    excerpt,
+    image,
+    tags: rawTags = [],
+    category: rawCategory,
+    client,
+    projectUrl,
+    technologies = [],
+    featured = false,
+    draft = false,
+    metadata = {},
+  } = data;
+
+  const slug = cleanSlug(id);
+  const publishDate = new Date(rawPublishDate);
+  const updateDate = rawUpdateDate ? new Date(rawUpdateDate) : undefined;
+
+  return {
+    id: id,
+    slug: slug,
+    permalink: await generatePermalink({ id, slug, publishDate, category: rawCategory }),
+
+    publishDate: publishDate,
+    updateDate: updateDate,
+
+    title: title,
+    excerpt: excerpt,
+    image: image,
+
+    category: rawCategory,
+    tags: rawTags,
+    client: client,
+    projectUrl: projectUrl,
+    technologies: technologies,
+    featured: featured,
+
+    draft: draft,
+
+    metadata,
+
+    Content: Content,
+  };
+};
+
+const load = async function (): Promise<Array<Portfolio>> {
+  const items = await getCollection('port');
+  const normalizedItems = items.map(async (item) => await getNormalizedPortfolio(item));
+
+  const results = (await Promise.all(normalizedItems))
+    .sort((a, b) => b.publishDate.valueOf() - a.publishDate.valueOf())
+    .filter((item) => !item.draft);
+
+  return results;
+};
+
+let _portfolioItems: Array<Portfolio>;
+
+/** */
+export const isPortfolioEnabled = true;
+export const isRelatedPortfolioEnabled = true;
+export const isPortfolioListRouteEnabled = true;
+export const isPortfolioItemRouteEnabled = true;
+export const isPortfolioCategoryRouteEnabled = true;
+export const isPortfolioTagRouteEnabled = true;
+
+export const portfolioListRobots = { index: true, follow: true };
+export const portfolioItemRobots = { index: true, follow: true };
+export const portfolioCategoryRobots = { index: true, follow: true };
+export const portfolioTagRobots = { index: true, follow: true };
+
+export const portfolioItemsPerPage = 12;
+
+/** */
+export const fetchPortfolioItems = async (): Promise<Array<Portfolio>> => {
+  if (!_portfolioItems) {
+    _portfolioItems = await load();
+  }
+
+  return _portfolioItems;
+};
+
+/** */
+export const findPortfolioItemsBySlugs = async (slugs: Array<string>): Promise<Array<Portfolio>> => {
+  if (!Array.isArray(slugs)) return [];
+
+  const items = await fetchPortfolioItems();
+
+  return slugs.reduce(function (r: Array<Portfolio>, slug: string) {
+    items.some(function (item: Portfolio) {
+      return slug === item.slug && r.push(item);
+    });
+    return r;
+  }, []);
+};
+
+/** */
+export const findPortfolioItemsByIds = async (ids: Array<string>): Promise<Array<Portfolio>> => {
+  if (!Array.isArray(ids)) return [];
+
+  const items = await fetchPortfolioItems();
+
+  return ids.reduce(function (r: Array<Portfolio>, id: string) {
+    items.some(function (item: Portfolio) {
+      return id === item.id && r.push(item);
+    });
+    return r;
+  }, []);
+};
+
+/** */
+export const findLatestPortfolioItems = async ({ count }: { count?: number }): Promise<Array<Portfolio>> => {
+  const _count = count || 4;
+  const items = await fetchPortfolioItems();
+
+  return items ? items.slice(0, _count) : [];
+};
+
+/** */
+export const findFeaturedPortfolioItems = async ({ count }: { count?: number }): Promise<Array<Portfolio>> => {
+  const _count = count || 4;
+  const items = await fetchPortfolioItems();
+  const featured = items.filter((item) => item.featured);
+
+  return featured ? featured.slice(0, _count) : [];
+};
+
+/** */
+export const getStaticPathsPortfolioList = async ({ paginate }: { paginate: PaginateFunction }) => {
+  if (!isPortfolioEnabled || !isPortfolioListRouteEnabled) return [];
+  return paginate(await fetchPortfolioItems(), {
+    params: { port: PORTFOLIO_BASE || undefined },
+    pageSize: portfolioItemsPerPage,
+  });
+};
+
+/** */
+export const getStaticPathsPortfolioItem = async () => {
+  if (!isPortfolioEnabled || !isPortfolioItemRouteEnabled) return [];
+  return (await fetchPortfolioItems()).flatMap((item) => ({
+    params: {
+      port: item.permalink,
+    },
+    props: { post: item },
+  }));
+};
+
+/** */
+export const getStaticPathsPortfolioCategory = async ({ paginate }: { paginate: PaginateFunction }) => {
+  if (!isPortfolioEnabled || !isPortfolioCategoryRouteEnabled) return [];
+
+  const items = await fetchPortfolioItems();
+  const categories = {};
+  items.map((item) => {
+    if (item.category) {
+      categories[item.category] = item.category;
+    }
+  });
+
+  return Array.from(Object.keys(categories)).flatMap((categorySlug) =>
+    paginate(
+      items.filter((item) => item.category && categorySlug === item.category),
+      {
+        params: { category: categorySlug, port: PORT_CATEGORY_BASE || undefined },
+        pageSize: portfolioItemsPerPage,
+        props: { category: categories[categorySlug] },
+      }
+    )
+  );
+};
+
+/** */
+export const getStaticPathsPortfolioTag = async ({ paginate }: { paginate: PaginateFunction }) => {
+  if (!isPortfolioEnabled || !isPortfolioTagRouteEnabled) return [];
+
+  const items = await fetchPortfolioItems();
+  const tags = {};
+  items.map((item) => {
+    if (Array.isArray(item.tags)) {
+      item.tags.map((tag) => {
+        tags[tag] = tag;
+      });
+    }
+  });
+
+  return Array.from(Object.keys(tags)).flatMap((tagSlug) =>
+    paginate(
+      items.filter((item) => Array.isArray(item.tags) && item.tags.includes(tagSlug)),
+      {
+        params: { tag: tagSlug, port: 'portfolio/tag' },
+        pageSize: portfolioItemsPerPage,
+        props: { tag: tags[tagSlug] },
+      }
+    )
+  );
+};
+
+/** */
+export async function getRelatedPortfolioItems(originalItem: Portfolio, maxResults: number = 4): Promise<Portfolio[]> {
+  const allItems = await fetchPortfolioItems();
+  const originalTagsSet = new Set(originalItem.tags || []);
+
+  const itemsWithScores = allItems.reduce((acc: { item: Portfolio; score: number }[], iteratedItem: Portfolio) => {
+    if (iteratedItem.slug === originalItem.slug) return acc;
+
+    let score = 0;
+    if (iteratedItem.category && originalItem.category && iteratedItem.category === originalItem.category) {
+      score += 5;
+    }
+
+    if (iteratedItem.tags) {
+      iteratedItem.tags.forEach((tag) => {
+        if (originalTagsSet.has(tag)) {
+          score += 1;
+        }
+      });
+    }
+
+    acc.push({ item: iteratedItem, score });
+    return acc;
+  }, []);
+
+  itemsWithScores.sort((a, b) => b.score - a.score);
+
+  const selectedItems: Portfolio[] = [];
+  let i = 0;
+  while (selectedItems.length < maxResults && i < itemsWithScores.length) {
+    selectedItems.push(itemsWithScores[i].item);
+    i++;
+  }
+
+  return selectedItems;
+}


### PR DESCRIPTION
- Added Grid and GridItem components for displaying portfolio items in a grid layout.
- Created List and ListItem components for a list view of portfolio items.
- Introduced Headline component for consistent section headings.
- Developed RelatedPosts component to show related portfolio items.
- Implemented SinglePost component for individual portfolio item pages.
- Added Tags component for displaying tags associated with portfolio items.
- Created ToPortLink component for navigation back to the portfolio overview.
- Developed PortHighlightedPosts widget to showcase featured portfolio items.
- Updated portfolio data structure and added new portfolio items.
- Enhanced routing for portfolio pages, including category and tag filtering.
- Updated navigation to link to the portfolio section.